### PR TITLE
Added inbuilt func. for running shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Want to help? Thanks! There are multiple areas you can help with.
 This is currently needed the most. Open lib/stdlib.js and create the function that you think should be part of greenlight. 
 Make sure it is prefixed with `greenlight_internal_` in order to not interfere with user-created functions.
 
-Then simply enter lib/implementations/inbuilt_function.js and add your function to `functionMap` by creating a new key with the name the function should have with the value of the internal name. Finally enter lib/tokens and include the function name in `inbuiltFunctionList`.
+Then simply enter lib/implementations/inbuilt_function.js and add your function to `functionMap` by creating a new key with the name the function should have with the value of the internal name. Finally enter lib/tokens.js and include the function name in `inbuiltFunctionList`.
 
 Finally, test if your function works, then submit your PR. Thanks! :)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Want to help? Thanks! There are multiple areas you can help with.
 This is currently needed the most. Open lib/stdlib.js and create the function that you think should be part of greenlight. 
 Make sure it is prefixed with `greenlight_internal_` in order to not interfere with user-created functions.
 
-Then simply enter lib/implementations/inbuilt_function.js and add your function to `functionMap` by creating a new key with the name the function should have with the value of the internal name.
+Then simply enter lib/implementations/inbuilt_function.js and add your function to `functionMap` by creating a new key with the name the function should have with the value of the internal name. Finally enter lib/tokens and include the function name in `inbuiltFunctionList`.
 
 Finally, test if your function works, then submit your PR. Thanks! :)
 

--- a/lib/implementations/inbuilt_function.js
+++ b/lib/implementations/inbuilt_function.js
@@ -8,6 +8,7 @@ let functionMap = {
     "exit": "greenlight_internal_exit",
     "isNumber": "greenlight_internal_is_number",
     "logError": "greenlight_internal_log_error",
+    "run": "await greenlight_internal_run",
 };
 
 exports.implementation = (rawToken) => {

--- a/lib/stdlib.js
+++ b/lib/stdlib.js
@@ -1,21 +1,22 @@
 const { stdin, stdout } = process;
 
+const { exec } = require('child_process');
 const greenlight_internal_http = require("http");
 const greenlight_internal_https = require("https");
 
 
 function greenlight_internal_prompt(question) {
-    return new Promise((resolve, reject) => {
-        stdin.resume();
-        stdout.write(question);
+	return new Promise((resolve, reject) => {
+		stdin.resume();
+		stdout.write(question);
 
-        stdin.on('data', data => resolve(data.toString().trim()));
-        stdin.on('error', err => reject(err));
-    });
+		stdin.on('data', data => resolve(data.toString().trim()));
+		stdin.on('error', err => reject(err));
+	});
 }
 
 function greenlight_internal_string_to_char_array(string) {
-    return Array.from(string);
+	return Array.from(string);
 }
 
 function greenlight_internal_http_get(url) {
@@ -34,7 +35,7 @@ function greenlight_internal_http_get(url) {
 			}).on("error", (err) => {
 				reject(err);
 			});
-			
+
 		} else if(url.startsWith("http")) {
 			greenlight_internal_http.get(url, (resp) => {
 				let data = '';
@@ -69,4 +70,18 @@ function greenlight_internal_log_with_color(text, color) {
 
 function greenlight_internal_log_error(text) {
 	greenlight_internal_log_with_color(text, "\x1b[31m");
+}
+
+function greenlight_internal_run(cmd) {
+	return new Promise((resolve, reject) => {
+		if (cmd == null) reject("No command to run.");
+		exec(cmd, (error, out, err) => {
+			if (error) {
+				reject(error)
+			} else {
+				resolve(out);
+				reject(err);
+			}
+		});
+	});
 }

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -89,7 +89,8 @@ let inbuiltFunctionList = [
 	"httpGet",
 	"exit",
 	"isNumber",
-	"logError"
+	"logError",
+	"run"
 ]; 
 
 temporaryRegex += inbuiltFunctionList[0] + "\\(";


### PR DESCRIPTION
## Executing commands with `run(command)`
- Included an inbuilt function `run(command)` to execute shell commands
- **Why do we need one?** - Could make sense in use cases where a user would like to access system information or maybe start a browser session, or, in Linux for instance, perform some privileged operation with `pkexec` _(the sky is the limit)_

## Fixed `README.md`
I had to beat around a bit to understand that the newly created function name must also be added to the `inbuiltFunctionList` in under `lib/tokens.js`. If not done, the script errors out with `ReferenceError`. Couldn't find that on the documentation hence added a small line illustrating the idea. I just realized that commit message for `5c015e1` is a little misleading - it's just a correction to the `tokens.js` file name as it appears in `README.md` in commit `c7260f6`.

## Example
![Screenshot from 2020-10-06 11-55-36](https://user-images.githubusercontent.com/15625446/95166134-f0d1c680-07ca-11eb-90b3-c4e03e3bc329.png)