### PR TITLE
Add helper functions for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,8 @@ httpGet("https://example.com/"); // Send a HTTP GET request to the provided URI,
 run("ls"); // Run a system command and receive output after the command has exited. Returns STDERR if an error occurs.
 sha256("data"); // Hash the provided data with SHA256 and return a hex string 
 sha3("data"); // Hash the provided data with SHA3-256 and return a hex string
+getObjectKeys(object); // Returns an array of the keys of a js object
+getObjectValues(object); // Returns an array of the values of a js object
+objToArray(object); // Returns an array of an object's key:value pairs
+objToJsonString(object); // Converts an object to a JSON string
 ```

--- a/lib/implementations/inbuilt_function.js
+++ b/lib/implementations/inbuilt_function.js
@@ -11,6 +11,10 @@ let functionMap = {
     "run": "await greenlight_internal_run",
     "sha256": "greenlight_internal_sha256",
     "sha3": "greenlight_internal_sha3",
+    "getObjectKeys": "greenlight_internal_get_object_keys",
+    "getObjectValues": "greenlight_internal_get_object_values",
+    "objToArray": "greenlight_internal_object_to_array",
+    "objToJsonString": "greenlight_internal_object_to_json_string",
 };
 
 exports.functionMap = functionMap;

--- a/lib/stdlib.js
+++ b/lib/stdlib.js
@@ -94,3 +94,19 @@ function greenlight_internal_sha256(data) {
 function greenlight_internal_sha3(data) {
 	return greenlight_internal_crypto.createHash("SHA3-256").update(data).digest("hex");
 }
+
+function greenlight_internal_get_object_keys(obj) {
+	return Object.keys(obj);
+}
+
+function greenlight_internal_get_object_values(obj) {
+	return Object.values(obj);
+}
+
+function greenlight_internal_object_to_array(obj) {
+	return Object.entries(obj);
+}
+
+function greenlight_internal_object_to_json_string(obj) {
+	return JSON.stringify(obj);
+}


### PR DESCRIPTION
My fourth contribution to the project.

### Changes included

- Added internal helper functions for objects:

1. Get an object's keys as an array
2. Get an object's values as an array
3. Get an object's key:value pairs as a nested array
4. Convert an object to a json string

- Update README to add entries for each helper function to the Standard Library section

### Value add

Makes it a little easier to perform the above functions on js objects.
